### PR TITLE
Correção do link da página de tradução

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Tradução do site http://www.promisejs.org/
 
-### Veja [AQUI](http://cerebrobr.github.io/promiseJS.br) a tradução!
+### Veja [AQUI](https://pedronauck.github.io/promiseJS.br/) a tradução!
 
 ## Como contribuir?
 


### PR DESCRIPTION
OBS: O link esta incorreto também na descrição do projeto, devendo ser alterado para: https://pedronauck.github.io/promiseJS.br/